### PR TITLE
Fix new names for the data attributes

### DIFF
--- a/src/component/ActivityCalendar.tsx
+++ b/src/component/ActivityCalendar.tsx
@@ -262,7 +262,7 @@ const ActivityCalendar: FunctionComponent<Props> = ({
               ry={blockRadius}
               className={styles.block}
               data-date={day.date}
-              data-tip={children ? getTooltipMessage(day) : undefined}
+              data-tip-html={children ? getTooltipMessage(day) : undefined}
               key={day.date}
               style={style}
             />


### PR DESCRIPTION
Fix new names for the data attributes in react-tooltip V4 -> V5 https://react-tooltip.com/docs/upgrade-guide/basic-examples-v4-v5

Content to de displayed in tooltip (html is priorized over content) https://react-tooltip.com/docs/options