### PR TITLE
Add hook on attribute data-theme

### DIFF
--- a/src/component/ActivityCalendar.tsx
+++ b/src/component/ActivityCalendar.tsx
@@ -8,6 +8,7 @@ import { type CSSProperties, Fragment, type ReactElement } from 'react';
 import { DEFAULT_LABELS, LABEL_MARGIN, NAMESPACE } from '../constants';
 import { useColorScheme } from '../hooks/useColorScheme';
 import { useIsClient } from '../hooks/useIsClient';
+import { useDataTheme } from '../hooks/useDataTheme';
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
 import styles from '../styles/styles.module.css';
 import type {
@@ -177,7 +178,8 @@ const ActivityCalendar = ({
 
   const theme = createTheme(themeProp, maxLevel + 1);
   const systemColorScheme = useColorScheme();
-  const colorScale = theme[colorScheme ?? systemColorScheme];
+  const dataTheme = useDataTheme();
+  const colorScale = theme[colorScheme ?? dataTheme ?? systemColorScheme];
 
   const useAnimation = !usePrefersReducedMotion();
 

--- a/src/hooks/useDataTheme.ts
+++ b/src/hooks/useDataTheme.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useDataTheme() {
+  const [dataTheme, setDataTheme] = useState<'light' | 'dark' | null>(null);
+
+  const onChange = (mutationList: Array<MutationRecord>) => {
+    for (const mutation of mutationList) {
+      if (mutation.type === 'attributes' && mutation.attributeName === 'data-theme') {
+        const theme = (mutation.target as HTMLElement).getAttribute('data-theme');
+
+        switch (theme) {
+          case 'dark':
+            setDataTheme('dark');
+            break;
+          case 'light':
+            setDataTheme('light');
+            break;
+          default:
+            setDataTheme(null);
+            break;
+        }
+      }
+    }
+  };
+
+  useEffect(() => {
+    const observer = new MutationObserver(onChange);
+
+    observer.observe(window.document.documentElement, { attributes: true });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return dataTheme;
+}


### PR DESCRIPTION
Some modern CSS framework as Bulma work with theme using the attribute `data-theme` on the HTML node element.
It could be a cool feature to support this in addition of the prefers-colors-scheme media-query.

I added a MutationObserver in a hook, the same way you did for the media-query.

The priority for the theme is now: `colorScheme` prop > `data-theme` > `prefers-colors-scheme`