### PR TITLE
Tooltip for the color legend

### DIFF
--- a/src/component/ActivityCalendar.stories.tsx
+++ b/src/component/ActivityCalendar.stories.tsx
@@ -429,6 +429,18 @@ export const Tooltips: Story = {
             </MuiTooltip>
           )}
         />
+        <p>
+          Using the <code>renderLegendBlock</code> prop, you can additionally add tooltips to the
+          color legend elements.
+        </p>
+        <ActivityCalendar
+          {...args}
+          data={data}
+          hideColorLegend={false}
+          renderLegendBlock={(block, legendElement) => (
+            <MuiTooltip title={`Level: ${legendElement.level}`}>{block}</MuiTooltip>
+          )}
+        />
         <h2>
           <a href="https://github.com/ReactTooltip/react-tooltip">react-tooltip</a>
         </h2>

--- a/src/component/ActivityCalendar.tsx
+++ b/src/component/ActivityCalendar.tsx
@@ -21,6 +21,7 @@ import type {
   Color,
   EventHandlerMap,
   Labels,
+  LegendElement,
   ReactEvent,
   SVGRectEventHandler,
   ThemeInput,
@@ -120,6 +121,12 @@ export interface Props {
    */
   renderBlock?: (block: BlockElement, activity: Activity) => ReactElement;
   /**
+   * Render prop for color legend blocks. For example, useful to wrap
+   * the element with a tooltip component. Use `React.cloneElement` to pass
+   * additional props to the element if necessary.
+   */
+  renderLegendBlock?: (block: BlockElement, legendElement: LegendElement) => ReactElement;
+  /**
    * Toggle to show weekday labels left to the calendar.
    */
   showWeekdayLabels?: boolean;
@@ -178,6 +185,7 @@ const ActivityCalendar = forwardRef<HTMLElement, Props>(
       maxLevel = 4,
       loading = false,
       renderBlock = undefined,
+      renderLegendBlock = undefined,
       showWeekdayLabels = false,
       style: styleProp = {},
       theme: themeProp = undefined,
@@ -318,17 +326,21 @@ const ActivityCalendar = forwardRef<HTMLElement, Props>(
               <span style={{ marginRight: '0.4em' }}>{labels.legend.less}</span>
               {Array(maxLevel + 1)
                 .fill(undefined)
-                .map((_, level) => (
-                  <svg width={blockSize} height={blockSize} key={level}>
-                    <rect
-                      width={blockSize}
-                      height={blockSize}
-                      fill={colorScale[level]}
-                      rx={blockRadius}
-                      ry={blockRadius}
-                    />
-                  </svg>
-                ))}
+                .map((_, level) => {
+                  const block = (
+                    <svg width={blockSize} height={blockSize} key={level}>
+                      <rect
+                        width={blockSize}
+                        height={blockSize}
+                        fill={colorScale[level]}
+                        rx={blockRadius}
+                        ry={blockRadius}
+                      />
+                    </svg>
+                  );
+
+                  return renderLegendBlock ? renderLegendBlock(block, { level }) : block;
+                })}
               <span style={{ marginLeft: '0.4em' }}>{labels.legend.more}</span>
             </div>
           )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,10 @@ export interface Activity {
   level: number;
 }
 
+export interface LegendElement {
+  level: number;
+}
+
 export type Week = Array<Activity | undefined>;
 
 export type Labels = Partial<{


### PR DESCRIPTION
For my use case (mood tracker) it'd be really nice to be able to add tooltips for the color legend blocks, so that it's easy to signify what each level/color stands for. I can imagine that it could be useful for some others too.

I achieved this simply by adding a `renderLegendBlock` prop that mirrors the `renderBlock` prop quite closely.