### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v4.1.2
+      - uses: actions/cache@v4.2.0
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.0](https://github.com/actions/cache/releases/tag/v4.2.0)** on 2024-12-05T16:45:49Z
