### PR TITLE
Added Month Splitting, Label Customization, Spacing between labels and activities, Month label placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "postbuild": "dts-bundle-generator src/index.tsx -o build/index.d.ts --no-check --no-banner --external-imports react date-fns",
     "prepublishOnly": "pnpm check && pnpm build",
     "start": "rollup -c -w",
-    "test": "jest",
-    "prepare": "husky"
+    "test": "jest"
   },
   "dependencies": {
     "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -87,10 +87,6 @@
       "react": "^19.0.0",
       "react-dom": "^19.0.0"
     },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "unrs-resolver"
-    ]
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "overrides": {
       "react": "^19.0.0",
       "react-dom": "^19.0.0"
-    },
+    }
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/src/component/ActivityCalendar.stories.tsx
+++ b/src/component/ActivityCalendar.stories.tsx
@@ -200,7 +200,7 @@ export const SplitByMonth: Story = {
         />
 
         <h2>Split by Month with Custom Styling</h2>
-        <p>Split by month with custom text styling and spacing:</p>
+        <p>Split by month with correct day-of-week positioning, custom text styling and spacing:</p>
         <ActivityCalendar
           {...args}
           data={data}

--- a/src/component/ActivityCalendar.stories.tsx
+++ b/src/component/ActivityCalendar.stories.tsx
@@ -81,6 +81,25 @@ const meta: Meta<ForwardedRef<Props>> = {
         },
       },
     },
+    splitByMonth: {
+      control: 'boolean',
+    },
+    monthLabelPosition: {
+      control: { type: 'select' },
+      options: ['top', 'bottom'],
+    },
+    monthLabelSpacing: {
+      control: { type: 'range', min: 0, max: 20, step: 1 },
+    },
+    weekLabelSpacing: {
+      control: { type: 'range', min: 0, max: 20, step: 1 },
+    },
+    monthLabelProps: {
+      control: 'object',
+    },
+    weekLabelProps: {
+      control: 'object',
+    },
   },
   decorators: [
     (Story, { args }) => {
@@ -130,6 +149,108 @@ export const Default: Story = {
     docs: {
       source: {
         code: '<ActivityCalendar data={data} />',
+      },
+    },
+  },
+}
+
+export const SplitByMonth: Story = {
+  args: {
+    ...defaultProps,
+    splitByMonth: true,
+  },
+  render: args => {
+    const data = useMemo(() => generateTestData({ maxLevel: args.maxLevel }), [args.maxLevel])
+    return (
+      <Container>
+        <h2>Configurable Label Spacing</h2>
+        <p>Use the controls to adjust month and week label spacing independently.</p>
+        <ActivityCalendar {...args} data={data} />
+
+        <h2>Custom Spacing Examples</h2>
+        <p>Month labels with extra spacing (16px):</p>
+        <ActivityCalendar {...args} data={data} monthLabelSpacing={16} />
+
+        <p style={{ marginTop: '20px' }}>Week labels with extra spacing (16px):</p>
+        <ActivityCalendar {...args} data={data} weekLabelSpacing={16} showWeekdayLabels={true} />
+
+        <p style={{ marginTop: '20px' }}>Both labels with custom spacing:</p>
+        <ActivityCalendar
+          {...args}
+          data={data}
+          monthLabelSpacing={12}
+          weekLabelSpacing={12}
+          showWeekdayLabels={true}
+        />
+
+        <h2>Custom Text Styling</h2>
+        <p>Month labels with custom font styling:</p>
+        <ActivityCalendar
+          {...args}
+          data={data}
+          monthLabelProps={{ fontSize: 16, fontWeight: 'bold', fill: '#2196f3' }}
+        />
+
+        <p style={{ marginTop: '20px' }}>Week labels with custom font styling:</p>
+        <ActivityCalendar
+          {...args}
+          data={data}
+          showWeekdayLabels={true}
+          weekLabelProps={{ fontSize: 10, fontFamily: 'monospace', fill: '#ff5722' }}
+        />
+
+        <h2>Split by Month with Custom Styling</h2>
+        <p>Split by month with custom text styling and spacing:</p>
+        <ActivityCalendar
+          {...args}
+          data={data}
+          splitByMonth={true}
+          monthLabelPosition="bottom"
+          monthLabelSpacing={16}
+          monthLabelProps={{ fontSize: 14, fontWeight: 'bold', fill: '#4caf50' }}
+          weekLabelProps={{ fontSize: 12, fontStyle: 'italic', fill: '#9c27b0' }}
+          showWeekdayLabels={true}
+        />
+      </Container>
+    )
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `// Default styling
+<ActivityCalendar data={data} />
+
+// Custom month label styling
+<ActivityCalendar
+  data={data}
+  monthLabelProps={{ fontSize: 16, fontWeight: 'bold', fill: '#2196f3' }}
+/>
+
+// Custom week label styling
+<ActivityCalendar
+  data={data}
+  showWeekdayLabels={true}
+  weekLabelProps={{ fontSize: 10, fontFamily: 'monospace', fill: '#ff5722' }}
+/>
+
+// Custom spacing and styling
+<ActivityCalendar
+  data={data}
+  monthLabelSpacing={16}
+  weekLabelSpacing={12}
+  monthLabelProps={{ fontSize: 14, fontWeight: 'bold' }}
+  weekLabelProps={{ fontSize: 12, fontStyle: 'italic' }}
+  showWeekdayLabels={true}
+/>
+
+// Split by month with custom styling
+<ActivityCalendar
+  data={data}
+  splitByMonth={true}
+  monthLabelPosition="bottom"
+  monthLabelSpacing={16}
+  monthLabelProps={{ fontSize: 14, fontWeight: 'bold', fill: '#4caf50' }}
+/>`,
       },
     },
   },

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -214,7 +214,10 @@ export function groupByWeeksForSplitByMonth(
     if (!monthGroups.has(monthKey)) {
       monthGroups.set(monthKey, [])
     }
-    monthGroups.get(monthKey)!.push(activity)
+
+    if (monthGroups.get(monthKey)) {
+      monthGroups.get(monthKey)?.push(activity)
+    }
   })
 
   const allWeeks: Array<Week> = []


### PR DESCRIPTION
Added option to splitByMonth - It will split the activity by month
Added option to place month labels to either top or bottom - It will place the month labels to top or bottom (default is top)
Added option to add spacing between week labels/month labels and activities - Add space between labels and activities
Added option to customize week/month labels - Add styling to labels
Fixed padding issue when splitByMonth was enabled
Added option "showFullYear" to show full year for the data provided if the data only spans 1 year but will not be used if the data spans multiple years

<img width="938" height="195" alt="image" src="https://github.com/user-attachments/assets/3639fb26-3d17-4325-ad98-c673dd287b5a" />

