### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,8 +15,8 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.57.0-noble
       options: --user 1001
     steps:
-      - uses: actions/checkout@v6.0.0
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/checkout@v6.0.1
+      - uses: actions/setup-node@v6.1.0
         with:
           node-version: lts/*
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.0
+      - uses: actions/checkout@v6.0.1
 
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/setup-node@v6.1.0
         with:
           node-version: node
 

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.0
+      - uses: actions/checkout@v6.0.1
         with:
           token: ${{ secrets.WORKFLOW_SECRET }} # Access token with `workflow` scope
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v6.1.0](https://github.com/actions/setup-node/releases/tag/v6.1.0)** on 2025-12-03T03:19:20Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.1](https://github.com/actions/checkout/releases/tag/v6.0.1)** on 2025-12-02T16:38:59Z
